### PR TITLE
Fix links in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # TimeseriesSurrogates.jl
 
-[![Build Status](https://travis-ci.org/kahaaga/TimeseriesSurrogates.jl.svg?branch=master)](https://travis-ci.org/kahaaga/TimeseriesSurrogates.jl)
+[![Build Status](https://travis-ci.org/JuliaDynamics/TimeseriesSurrogates.jl.svg?branch=master)](https://travis-ci.org/JuliaDynamics/TimeseriesSurrogates.jl)
 
-[![codecov](https://codecov.io/gh/kahaaga/TimeseriesSurrogates.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/kahaaga/TimeseriesSurrogates.jl)
+[![codecov](https://codecov.io/gh/JuliaDynamics/TimeseriesSurrogates.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/JuliaDynamics/TimeseriesSurrogates.jl)
 
-[![](https://img.shields.io/badge/docs-stable-blue.svg)](https://kahaaga.github.io/TimeseriesSurrogates.jl/latest)
+[![](https://img.shields.io/badge/docs-stable-blue.svg)](https://JuliaDynamics.github.io/TimeseriesSurrogates.jl/latest)
 
 
 A Julia library for generating surrogate data. Check out the
-[documentation](https://kahaaga.github.io/TimeseriesSurrogates.jl/latest) for information
+[documentation](https://JuliaDynamics.github.io/TimeseriesSurrogates.jl/latest) for information
 on how to use it.


### PR DESCRIPTION
With the move of the repository, the links to travis, codecov and the docs changed as well. 
This fixes them.