### PR TITLE
New surrogate method for multi dimensional data

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "TimeseriesSurrogates"
 uuid = "c804724b-8c18-5caa-8579-6025a0767c70"
 authors = ["Kristian Agasøster Haaga <kahaaga@gmail.com>", "George Datseris"]
 repo = "https://github.com/kahaaga/TimeseriesSurrogates.jl.git"
-version = "1.0.0"
+version = "1.1.0"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"
@@ -12,14 +12,15 @@ Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 InplaceOps = "505f98c9-085e-5b2c-8e89-488be7bf1f34"
 Interpolations = "a98d9a8b-a2ab-59e6-89dd-64a1c18fca59"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 Wavelets = "29a6e085-ba6d-5f35-a997-948ac2efa89a"
 
 [compat]
 AbstractFFTs = "= 0.4.1, 0.5"
-DelayEmbeddings = "1.5.1"
 DSP = "^0.5.2, 0.6, ^1"
+DelayEmbeddings = "1.5.1"
 Distributions = "0.21, 1, 0.23"
 InplaceOps = "^0.3.0, ^1"
 Interpolations = "^0.12, ^1"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,6 +1,7 @@
 [deps]
+Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 DocumenterTools = "35a29f4d-8980-5a13-9543-d66fff28ecb8"
+DynamicalSystems = "61744808-ddfa-5f27-97ff-6e42cc95d634"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 TimeseriesSurrogates = "c804724b-8c18-5caa-8579-6025a0767c70"
-Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -41,7 +41,7 @@ PAGES = [
         "Truncated FT/AAFT" => "constrained/truncated_fourier_transform.md",
         "Pseudo-periodic" => "constrained/pps.md",
         "Wavelet-based" => "constrained/wls.md",
-        "Multidimensional surrogates" => "multidim.md",
+        "Multidimensional surrogates" => "constrained/multidim.md",
     ],
     "Utility systems" => "man/exampleprocesses.md"
 ]

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -5,6 +5,7 @@ CI && Pkg.activate(@__DIR__)
 CI && Pkg.instantiate()
 CI && (ENV["GKSwstype"] = "100")
 using TimeseriesSurrogates
+using DynamicalSystems
 using Random
 using Distributions
 using Plots

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -40,7 +40,8 @@ PAGES = [
         "Amplitude-adjusted FT" => "constrained/amplitude_adjusted.md",
         "Truncated FT/AAFT" => "constrained/truncated_fourier_transform.md",
         "Pseudo-periodic" => "constrained/pps.md",
-        "Wavelet-based" => "constrained/wls.md"
+        "Wavelet-based" => "constrained/wls.md",
+        "Multidimensional surrogates" => "multidim.md",
     ],
     "Utility systems" => "man/exampleprocesses.md"
 ]

--- a/docs/src/constrained/multidim.md
+++ b/docs/src/constrained/multidim.md
@@ -1,0 +1,29 @@
+# Multidimensional surrogates
+Multidimensional surrogates operate typically on input `Datasets` (see e.g. [DynamicalSystems.jl](https://juliadynamics.github.io/DynamicalSystems.jl/dev/embedding/dataset/) package) and output the same type.
+
+## Shuffle dimensions
+This surrogate was made to distinguish multidimensional data with *structure in the state space* from multidimensional noise.
+
+Here is a simple application that shows that the distinction is successful for a system that we know a-priori is deterministic and has structure in the state space.
+
+```@example multidim
+using DynamicalSystems, TimeseriesSurrogates, Plots
+
+D = 7
+lo = Systems.lorenz96(D, range(0; length = D, step = 0.1); F = 8.0)
+X = trajectory(lo, 1000, dt = 0.1, Ttr = 100.0)
+
+e = 10.0 .^ range(-4, 1, length = 22)
+CX = correlationsum(X, e; w = 5)
+
+le = log10.(e)
+plot(le, log10.(CX))
+
+sg = surrogenerator(X, ShuffleDimensions())
+for i in 1:10
+    Z = sg()
+    CZ = correlationsum(Z, e)
+    plot!(le, log10.(CZ), alpha = 0.5, lw = 0.5, color = "k", ls = ":")
+end
+plot!(xlabel = "log(e)", ylabel = "log(C)");
+```

--- a/docs/src/constrained/multidim.md
+++ b/docs/src/constrained/multidim.md
@@ -17,13 +17,13 @@ e = 10.0 .^ range(-4, 1, length = 22)
 CX = correlationsum(X, e; w = 5)
 
 le = log10.(e)
-plot(le, log10.(CX))
+p1 = plot(le, log10.(CX), legend = false)
 
 sg = surrogenerator(X, ShuffleDimensions())
 for i in 1:10
     Z = sg()
     CZ = correlationsum(Z, e)
-    plot!(le, log10.(CZ), alpha = 0.5, lw = 0.5, color = "k", ls = ":")
+    plot!(p1, le, log10.(CZ), color = "black")
 end
-plot!(xlabel = "log(e)", ylabel = "log(C)");
+xlabel!("log(e)"); ylabel!("log(C)");
 ```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -31,6 +31,7 @@ TAAFT
 IAAFT
 PseudoPeriodic
 WLS
+ShuffleDimensions
 ```
 
 ### Utils

--- a/src/TimeseriesSurrogates.jl
+++ b/src/TimeseriesSurrogates.jl
@@ -28,6 +28,7 @@ include("methods/iaaft.jl")
 include("methods/truncated_fourier.jl")
 include("methods/wavelet_based.jl")
 include("methods/pseudoperiodic.jl")
+include("methods/multidimensional.jl")
 
 # Visualization routine for time series + surrogate + periodogram/acf/histogram
 using Requires

--- a/src/methods/multidimensional.jl
+++ b/src/methods/multidimensional.jl
@@ -1,3 +1,4 @@
+using DelayEmbeddings, Random
 export ShuffleDimensions
 
 """
@@ -11,10 +12,14 @@ suited to distinguish deterministic datasets from high dimensional noise.
 struct ShuffleDimensions <: Surrogate end
 
 function surrogenerator(x, sd::ShuffleDimensions)
-    @assert isa Dataset "input `x` must be `DelayEmbeddings.Dataset` for `ShuffleDimensions`"
+    @assert x isa Dataset "input `x` must be `DelayEmbeddings.Dataset` for `ShuffleDimensions`"
     return SurrogateGenerator(sd, x, nothing)
 end
 
-function (rf::SurrogateGenerator{<:ShuffleDimensions})()
-    # actually do the shuffling
+function (sg::SurrogateGenerator{<:ShuffleDimensions})()
+    data = copy(sg.x.data)
+    for i in 1:length(data)
+        data[i] = shuffle(data[i])
+    end
+    return Dataset(data)
 end

--- a/src/methods/multidimensional.jl
+++ b/src/methods/multidimensional.jl
@@ -1,0 +1,20 @@
+export ShuffleDimensions
+
+"""
+    ShuffleDimensions()
+Multidimensional surrogates of input *datasets* (`DelayEmbeddings.Dataset`, which are
+also multidimensional) that have shuffled dimensions in each point.
+
+These surrogates destroy the state space structure of the dataset and are thus
+suited to distinguish deterministic datasets from high dimensional noise.
+"""
+struct ShuffleDimensions <: Surrogate end
+
+function surrogenerator(x, sd::ShuffleDimensions)
+    @assert isa Dataset "input `x` must be `DelayEmbeddings.Dataset` for `ShuffleDimensions`"
+    return SurrogateGenerator(sd, x, nothing)
+end
+
+function (rf::SurrogateGenerator{<:ShuffleDimensions})()
+    # actually do the shuffling
+end

--- a/src/methods/multidimensional.jl
+++ b/src/methods/multidimensional.jl
@@ -19,7 +19,7 @@ end
 function (sg::SurrogateGenerator{<:ShuffleDimensions})()
     data = copy(sg.x.data)
     for i in 1:length(data)
-        data[i] = shuffle(data[i])
+        @inbounds data[i] = shuffle(data[i])
     end
     return Dataset(data)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,7 +8,7 @@ ts_nan = cumsum(randn(N))
 ts_nan[1] = NaN
 x = cos.(range(0, 20π, length = N)) .+ randn(N)*0.05
 
-@testset "WLS" begin 
+@testset "WLS" begin
     wts = WLS()
     wts = WLS(AAFT())
     s = surrogate(x, wts)
@@ -28,7 +28,7 @@ end
 	#TODO: Test for noiseradius
 end
 
-@testset "BlockShuffle" begin 
+@testset "BlockShuffle" begin
     bs1 = BlockShuffle()
     bs2 = BlockShuffle(4)
     s1 = surrogate(x, bs1)
@@ -40,7 +40,7 @@ end
     @test all([s2[i] ∈ x for i = 1:N])
 end
 
-@testset "RandomShuffle" begin 
+@testset "RandomShuffle" begin
     rs = RandomShuffle()
     s = surrogate(x, rs)
 
@@ -48,25 +48,25 @@ end
     @test all([s[i] ∈ x for i = 1:N])
 end
 
-@testset "AAFT" begin 
-    aaft = AAFT()    
+@testset "AAFT" begin
+    aaft = AAFT()
     s = surrogate(x, aaft)
 
     @test length(s) == length(x)
     @test all([s[i] ∈ x for i = 1:N])
 end
 
-@testset "IAAFT" begin 
-    iaaft = IAAFT()    
+@testset "IAAFT" begin
+    iaaft = IAAFT()
     s = surrogate(x, iaaft)
 
     @test length(s) == length(x)
     @test all([s[i] ∈ x for i = 1:N])
 end
 
-@testset "TFTS" begin 
-    method_preserve_lofreq = TFTS(0.05) 
-    method_preserve_hifreq = TFTS(-0.05)    
+@testset "TFTS" begin
+    method_preserve_lofreq = TFTS(0.05)
+    method_preserve_hifreq = TFTS(-0.05)
 
     s = surrogate(x, method_preserve_lofreq)
     @test length(s) == length(x)
@@ -78,14 +78,14 @@ end
 end
 
 
-@testset "TAAFT" begin 
-    method_preserve_lofreq = TAAFT(0.05) 
-    method_preserve_hifreq = TAAFT(-0.05)    
-   
+@testset "TAAFT" begin
+    method_preserve_lofreq = TAAFT(0.05)
+    method_preserve_hifreq = TAAFT(-0.05)
+
     s = surrogate(x, method_preserve_lofreq)
     @test length(s) == length(x)
     @test all([s[i] ∈ x for i = 1:N])
-    
+
     s = surrogate(x, method_preserve_hifreq)
     @test length(s) == length(x)
     @test all([s[i] ∈ x for i = 1:N])
@@ -94,7 +94,7 @@ end
 end
 
 
-@testset "RandomFourier" begin 
+@testset "RandomFourier" begin
     @testset "random phases" begin
         phases = true
         rf = RandomFourier(phases)
@@ -112,8 +112,17 @@ end
     end
 end
 
+using DelayEmbeddings
+@testset "ShufleDims" begin
+	X = Dataset(rand(100, 3))
+	Y = surrogate(X, ShuffleDimensions())
+	for i in 1:100
+		@test sort(X[i]) == sort(Y[i])
+	end
+end
 
-#= 
+
+#=
 @testset "IAAFT" begin
     # With pre-planning
     method = IAAFT(ts)
@@ -126,5 +135,5 @@ end
     surr = surrogate(ts, method)
     @test length(ts) == length(surr)
     @test all(sort(ts) .== sort(surr))
-end 
+end
 =#


### PR DESCRIPTION
I have a research project with U. Parlitz (Uni Goettingen) about estimating fractal dimensions. There we use exclusively multi-dimensional data, and we thought of a very simple surrogate method for distinguishing determinism versus multi dimensional noise.

In principle one could get the first timeseries of the data, and do the standard AAFT surrogates on this, but we believe one should be more accurate by leveraging all timeseries in the dataset.

Thus, this simple method makes surrogates that shuffle the dimensions of each data points. 

It works very well in what it is supposed to do, showing that deterministic signals will have sufficiently smaller dimension than their random counterparts:

```julia
using DynamicalSystems, TimeseriesSurrogates

D = 7
lo = Systems.lorenz96(D, range(0; length = D, step = 0.1); F = 8.0)
X = trajectory(lo, 1000, dt = 0.1, Ttr = 100.0)

e = 10.0 .^ range(-4, 1, length = 22)
CX = correlationsum(X, e; w = 5)

figure()
le = log10.(e)
plot(le, log10.(CX))

i = findfirst(z -> z > 0, CX)

@show linear_region(le[i:end], log10.(CX)[i:end])

sg = surrogenerator(X, ShuffleDimensions())
for i in 1:10
    Z = sg()
    CZ = correlationsum(Z, e)
    plot(le, log10.(CZ), alpha = 0.5, lw = 0.5, color = "k", ls = ":")
    @show linear_region(le, log10.(CZ))[2]
end
xlabel("log(e)")
ylabel("log(C)")
```

![image](https://user-images.githubusercontent.com/19669089/85138401-fc60a800-b242-11ea-93b3-e642c44c8b4e.png)