### PR TITLE
Fix type conversions to allow Float32 time series

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "TimeseriesSurrogates"
 uuid = "c804724b-8c18-5caa-8579-6025a0767c70"
 authors = ["Kristian Agasøster Haaga <kahaaga@gmail.com>", "George Datseris"]
 repo = "https://github.com/JuliaDynamics/TimeseriesSurrogates.jl.git"
-version = "2.3.0"
+version = "2.3.1"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/src/methods/iaaft.jl
+++ b/src/methods/iaaft.jl
@@ -18,7 +18,7 @@ surrogate are coarse-grained and the powers are averaged over `W` equal-width
 frequency bins. The iteration procedure ends when the relative deviation
 between the periodograms is less than `tol` (or when `M` is reached).
 
-IAAFT, just as AAFT, can be used to test the null hypothesis that the data 
+IAAFT, just as AAFT, can be used to test the null hypothesis that the data
 come from a monotonic nonlinear transformation of a linear Gaussian process.
 
 [^SchreiberSchmitz1996]: T. Schreiber; A. Schmitz (1996). "Improved Surrogate Data for Nonlinearity Tests". [Phys. Rev. Lett. 77 (4)](https://journals.aps.org/prl/abstract/10.1103/PhysRevLett.77.635)
@@ -61,7 +61,7 @@ function surrogenerator(x, method::IAAFT, rng = Random.default_rng())
 
     # Periodograms
     𝓕p = prepare_spectrum(x, forward)
-    xpower = zeros(length(𝓕)); powerspectrum!(𝓕p, xpower, x, forward)
+    xpower = similar(𝓕) .|> real; powerspectrum!(𝓕p, xpower, x, forward)
     spower = copy(xpower)
 
     # Binned periodograms
@@ -69,15 +69,15 @@ function surrogenerator(x, method::IAAFT, rng = Random.default_rng())
     spowerᵦ = interpolated_spectrum(spower, method.W)
 
     init = (
-        forward = forward, 
-        inverse = inverse, 
-        𝓕 = 𝓕, 
+        forward = forward,
+        inverse = inverse,
+        𝓕 = 𝓕,
         𝓕p = 𝓕p,
-        r = r, 
-        ϕ = ϕ, 
-        m = m, 
-        x_sorted = x_sorted, 
-        xpower = xpower, 
+        r = r,
+        ϕ = ϕ,
+        m = m,
+        x_sorted = x_sorted,
+        xpower = xpower,
         spower = spower,
         xpowerᵦ = xpowerᵦ,
         spowerᵦ = spowerᵦ,
@@ -101,18 +101,18 @@ function (sg::SurrogateGenerator{<:IAAFT})()
 
     sum_old, sum_new = 0.0, 0.0
     iter = 1
-    while iter <= M        
+    while iter <= M
         mul!(𝓕, forward, s)
         ϕ .= angle.(𝓕)
         𝓕 .= r .* exp.(ϕ .* 1im)
 
-        # TODO: Unfortunately, we can't simply do ldiv! here to avoid allocations. 
-        # But, although FFTW does not yet have irfft!, it will probably have. 
-        # See https://github.com/JuliaMath/FFTW.jl/pull/222. 
-        # Once that PR is merged, we should replace the following line with 
+        # TODO: Unfortunately, we can't simply do ldiv! here to avoid allocations.
+        # But, although FFTW does not yet have irfft!, it will probably have.
+        # See https://github.com/JuliaMath/FFTW.jl/pull/222.
+        # Once that PR is merged, we should replace the following line with
         # the in-place version.
         ######################################################################
-        s .= inverse * 𝓕 
+        s .= inverse * 𝓕
         sortperm!(ix, s)
         s[ix] .= x_sorted
 
@@ -120,7 +120,7 @@ function (sg::SurrogateGenerator{<:IAAFT})()
         interpolated_spectrum!(spowerᵦ, spower, W)
         if iter == 1
             sum_old = sum((xpowerᵦ .- xpowerᵦ) .^ 2) / sum(xpowerᵦ .^ 2)
-        else 
+        else
             sum_new = sum((xpowerᵦ .- spowerᵦ) .^ 2) / sum(xpowerᵦ .^ 2)
             if abs(sum_old - sum_new) < tol
                 iter = M + 1

--- a/test/reproducibility.jl
+++ b/test/reproducibility.jl
@@ -4,6 +4,7 @@ ts = cumsum(randn(N))
 ts_nan = cumsum(randn(N))
 ts_nan[1] = NaN
 x = cos.(range(0, 20π, length = N)) .+ randn(N)*0.05
+xf = x .|> Float32
 t = (0:N-1) + rand(N)
 
 all_conceivable_methods = [
@@ -45,6 +46,17 @@ methodnames = [string(nameof(typeof(x))) for x in all_conceivable_methods]
         y = surrogate(x, method, rng)
         rng = Random.MersenneTwister(1234)
         z = surrogate(x, method, rng)
+        @test y == z
+    end
+end
+
+@testset "Float32 handling" begin
+    @testset "$n" for (i, n) in enumerate(methodnames)
+        method = all_conceivable_methods[i]
+        rng = Random.MersenneTwister(1234)
+        y = surrogate(xf, method, rng)
+        rng = Random.MersenneTwister(1234)
+        z = surrogate(xf, method, rng)
         @test y == z
     end
 end


### PR DESCRIPTION
Currently, methods such as `IAAFT` fail on `Vector{Float32}` time series. This is solved by promoting the power spectrum to the `eltype` of the input time series.